### PR TITLE
Copy all package files

### DIFF
--- a/lib/pkgr/app.rb
+++ b/lib/pkgr/app.rb
@@ -215,8 +215,8 @@ module Pkgr
             #{debian_steps.join(" &&\n")}'
         }
         sh cmd
-        # Fetch the .deb, and put it in the `pkg` directory
-        sh "scp #{host}:/tmp/#{name}_#{version}*.deb pkg/"
+        # Fetch all package files, and put it in the `pkg` directory
+        sh "scp #{host}:/tmp/#{name}_#{version}* pkg/"
       end
     end
 


### PR DESCRIPTION
Copy all package files that built (including .changes, .dsc and .tar.gz), not only .deb to pkg directory. Needed to upload a package via dput/dupload.
