### PR TITLE
Use 1.3.5 as default bundler, compatible and faster thanks to query api.

### DIFF
--- a/lib/pkgr/app.rb
+++ b/lib/pkgr/app.rb
@@ -252,7 +252,7 @@ module Pkgr
 
     private
     def bundler_version
-      @config.fetch('bundler_version') { '1.1.3' }
+      @config.fetch('bundler_version') { '1.3.5' }
     end
 
     def debian_file(filename)


### PR DESCRIPTION
Updated default version of bundler to use with pkgr, as recent bundler are faster (rubygems query api).
