### PR TITLE
Fixed spec_helper require for compatibility with rspec 2.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'spec'
+require 'rspec'
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'pkgr'


### PR DESCRIPTION
Recent rspec do not allow to `require 'spec'` anymore.
