### PR TITLE
Switched Gemfile source to 'https://rubygems.org' (fix rubygems warning)...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
Recent bundler encourage to use `source 'https://rubygems.org'` instead of `source :rubygems`. If the symbol version is used a warning is displayed.
