### PR TITLE
Use application install prefix as explicit $HOME for application user.

### DIFF
--- a/lib/pkgr/data/debian/postinst.erb
+++ b/lib/pkgr/data/debian/postinst.erb
@@ -33,7 +33,7 @@ case "$1" in
         " > /usr/bin/$NAME && chmod a+x /usr/bin/$NAME
         # Creating the user if it does not exist
         if ! getent passwd $USER > /dev/null; then
-          adduser --no-create-home --system --group $GROUP
+          adduser --home $PREFIX --no-create-home --system --group $GROUP
         fi
         chown -R $USER.$GROUP /etc/$NAME/
         chown -R $USER.$GROUP /var/db/$NAME/


### PR DESCRIPTION
The user created in the `postinst` script does not have a special home but it still has a homedir in `/home` by default.
I believe that it would make sense to use the installation directory as the user's homedir, even if the user won't be allowed to login.
