### PR TITLE
Deal with buildpacks without default_process_types

### DIFF
--- a/lib/pkgr/builder.rb
+++ b/lib/pkgr/builder.rb
@@ -121,6 +121,8 @@ module Pkgr
       @procfile_entries ||= begin
         default_process_types = YAML.load_file(release_file)["default_process_types"]
 
+        default_process_types = {} unless default_process_types
+
         entries = if File.exist?(procfile)
           File.read(procfile).gsub("\r\n","\n").split("\n").map do |line|
             if line =~ /^([A-Za-z0-9_]+):\s*(.+)$/


### PR DESCRIPTION
Although the buildpack API document
(https://devcenter.heroku.com/articles/buildpack-api#bin-release) seems
to suggest everything will have default_process_types key looking at
lots of the third party buildpacks they don't
(https://devcenter.heroku.com/articles/third-party-buildpacks)

This patch ensures that the merge on line 134 (now 136) doesn't throw an
exception because default_process_types is Nil, which happens for
example with this buildpack: https://github.com/ddollar/buildpack-test
