### PR TITLE
Set the created users' HOME to APP_HOME.

### DIFF
--- a/data/hooks/preinstall.sh
+++ b/data/hooks/preinstall.sh
@@ -12,12 +12,12 @@ if ! getent passwd "${APP_USER}" > /dev/null; then
     if ! getent group "${APP_GROUP}" > /dev/null ; then
       groupadd --system "${APP_GROUP}"
     fi
-    adduser "${APP_USER}" -g "${APP_GROUP}" --system --create-home --shell /bin/bash
+    adduser "${APP_USER}" -g "${APP_GROUP}" --system --home <%= home %> --shell /bin/bash
   else
     if ! getent group "${APP_GROUP}" > /dev/null; then
       addgroup "${APP_GROUP}" --system --quiet
     fi
-    adduser "${APP_USER}" --disabled-login --ingroup "${APP_GROUP}" --system --quiet --shell /bin/bash
+    adduser "${APP_USER}" --disabled-login --ingroup "${APP_GROUP}" --system --quiet --home <%= home %> --shell /bin/bash
   fi
 fi
 


### PR DESCRIPTION
This will ensure that apps depending on stuff in .profile.d and the like
will work correctly.

Necessary for #37 to work with heroku-buildpack-python (and likely others)
