### PR TITLE
Fedora

### DIFF
--- a/lib/pkgr.rb
+++ b/lib/pkgr.rb
@@ -12,9 +12,4 @@ module Pkgr
     class UnknownDistribution < Base; end
     class ConfigurationInvalid < Base; end
   end
-
-  def data_dir
-    File.expand_path("../../data", __FILE__)
-  end
-  module_function :data_dir
 end

--- a/lib/pkgr/cli.rb
+++ b/lib/pkgr/cli.rb
@@ -48,6 +48,12 @@ module Pkgr
     method_option :description,
       :type => :string,
       :desc => "Project description"
+    method_option :vendor,
+      :type => :string,
+      :desc => "Vendor name for package"
+    method_option :category,
+      :type => :string,
+      :desc => "Category this package belongs to (default: 'none')"
     method_option :version,
       :type => :string,
       :desc => "Package version (if git directory given, it will use the latest git tag available)"

--- a/lib/pkgr/cli.rb
+++ b/lib/pkgr/cli.rb
@@ -5,6 +5,13 @@ require 'pkgr/env'
 
 module Pkgr
   class CLI < Thor
+
+    no_tasks do
+      def self.default_data_dir
+        "#{File.expand_path("../../../data", __FILE__)}"
+      end
+    end
+
     class_option :verbose,
       :type => :boolean,
       :default => false,
@@ -123,6 +130,10 @@ module Pkgr
       :type => :boolean,
       :default => true,
       :desc => "Verifies output package"
+    method_option :data_dir,
+      :type => :string,
+      :default => default_data_dir,
+      :desc => "Path to data directory. Can be used for overriding default templates, hooks(pre-, post- scripts), configs (buildpacks, distro dependencies), environments, etc. To retrieve default files you can use data command"
 
     def package(tarball)
       Pkgr.level = Logger::INFO if options[:verbose]
@@ -144,5 +155,13 @@ module Pkgr
       puts "     ! SYSTEM ERROR: #{e.class.name} : #{e.message}"
       raise e
     end
+
+
+    desc "data DIRECTORY", "Copy data templates into destination DIRECTORY for modification purpose and reusing it later within --data-dir option. "
+
+    def data(destination_path)
+      FileUtils.copy_entry Pkgr::CLI.default_data_dir, destination_path
+    end
+
   end
 end

--- a/lib/pkgr/config.rb
+++ b/lib/pkgr/config.rb
@@ -112,6 +112,10 @@ module Pkgr
       @table[:env].is_a?(Pkgr::Env) ? @table[:env] : Pkgr::Env.new(@table[:env])
     end
 
+    def data_dir
+      @table[:data_dir] || Pkgr::CLI.default_data_dir
+    end
+
     def valid?
       @errors = []
       @errors.push("name can't be blank") if name.nil? || name.empty?

--- a/lib/pkgr/config.rb
+++ b/lib/pkgr/config.rb
@@ -92,6 +92,14 @@ module Pkgr
       @table[:homepage] || "http://example.com/no-uri-given"
     end
 
+    def vendor
+      @table[:vendor] || ""
+    end
+
+    def category
+      @table[:category] || "none"
+    end
+
     def description
       @table[:description] || "No description given"
     end

--- a/lib/pkgr/distributions/base.rb
+++ b/lib/pkgr/distributions/base.rb
@@ -120,7 +120,7 @@ module Pkgr
         list = []
         procfile_entries.select(&:daemon?).each do |process|
           Pkgr.debug "Adding #{process.inspect} to initialization scripts"
-          runner.templates(process, app_name).each do |template|
+          runner.templates(process, app_name, config.data_dir).each do |template|
             list.push [process, template]
           end
         end
@@ -173,7 +173,7 @@ module Pkgr
       end # def load_buildpack_list
 
       def data_file(*names)
-        File.new(File.join(Pkgr.data_dir, *names))
+        File.new(File.join(config.data_dir, *names))
       end
 
       def generate_hook_file(hook_name)

--- a/lib/pkgr/distributions/fedora.rb
+++ b/lib/pkgr/distributions/fedora.rb
@@ -28,28 +28,39 @@ module Pkgr
       end
 
       def fpm_command(build_dir)
-        %{
-          fpm -t rpm -s dir --verbose --force \
-          -C "#{build_dir}" \
-          -n "#{config.name}" \
-          --version "#{config.version}" \
-          --iteration "#{config.iteration}" \
-          --url "#{config.homepage}" \
-          --provides "#{config.name}" \
-          --deb-user "root" \
-          --deb-group "root" \
-          -a "#{config.architecture}" \
-          --description "#{config.description}" \
-          --maintainer "#{config.maintainer}" \
-          --template-scripts \
-          --before-install #{preinstall_file} \
-          --after-install #{postinstall_file} \
-          --before-remove #{preuninstall_file} \
-          --after-remove #{postuninstall_file} \
-          #{dependencies(config.dependencies).map{|d| "-d '#{d}'"}.join(" ")} \
-          .
-        }
+        "fpm #{fpm_args(build_dir).join(" ")}"
       end
+
+      private
+
+        def fpm_args(build_dir)
+          args = []
+          args << %{-t rpm}
+          args << %{-s dir}
+          args << %{--verbose}
+          args << %{--force}
+          args << %{--exclude '**/.git**'}
+          args << %{-C "#{build_dir}"}
+          args << %{-n "#{config.name}"}
+          args << %{--version "#{config.version}"}
+          args << %{--iteration "#{config.iteration}"}
+          args << %{--url "#{config.homepage}"}
+          args << %{--provides "#{config.name}"}
+          args << %{--license "#{config.license}"} if config.license
+          args << %{--deb-user root}
+          args << %{--deb-group root}
+          args << %{--vendor "#{config.vendor}"}
+          args << %{-a "#{config.architecture}"}
+          args << %{--description "#{config.description}"}
+          args << %{--maintainer "#{config.maintainer}"}
+          args << %{--template-scripts}
+          args << %{--before-install "#{preinstall_file}"}
+          args << %{--after-install "#{postinstall_file}"}
+          args << %{--before-remove "#{preuninstall_file}"}
+          args << %{--after-remove "#{postuninstall_file}"}
+          args << dependencies(config.dependencies).map{|d| "-d '#{d}'"}.join(" ")
+          args << "."
+        end
     end
   end
 end

--- a/lib/pkgr/distributions/runner.rb
+++ b/lib/pkgr/distributions/runner.rb
@@ -1,6 +1,9 @@
 module Pkgr
   module Distributions
     class Runner < Struct.new(:type, :version, :cli)
+
+      attr_accessor :data_dir
+
       def sysv?
         type == "sysv"
       end
@@ -9,7 +12,8 @@ module Pkgr
         type == "upstart"
       end
 
-      def templates(process, app_name)
+      def templates(process, app_name, data_dir)
+        @data_dir = data_dir
         send("templates_#{type}", process, app_name)
       end
 
@@ -32,7 +36,7 @@ module Pkgr
       end
 
       def data_file(name)
-        File.new(File.join(Pkgr.data_dir, "init", type, version, name))
+        File.new(File.join(data_dir, "init", type, version, name))
       end
     end
   end

--- a/lib/pkgr/version.rb
+++ b/lib/pkgr/version.rb
@@ -1,3 +1,3 @@
 module Pkgr
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end

--- a/spec/data/cli/cli.sh_spec.rb
+++ b/spec/data/cli/cli.sh_spec.rb
@@ -191,7 +191,7 @@ describe "bash cli" do
       FileUtils.mkdir_p target_dir
 
       runner = Pkgr::Distributions::Runner.new(type, version.join("-"))
-      runner.templates(Pkgr::Process.new(process_name, process_command), config.name).each do |template|
+      runner.templates(Pkgr::Process.new(process_name, process_command), config.name, config.data_dir).each do |template|
         Dir.chdir(target_dir) do
           config.process_name = process_name
           config.process_command = process_command

--- a/spec/lib/pkgr/cli_spec.rb
+++ b/spec/lib/pkgr/cli_spec.rb
@@ -5,4 +5,18 @@ describe Pkgr::CLI do
     expect(Pkgr::CLI.class_options.keys).to include(:verbose)
     expect(Pkgr::CLI.class_options.keys).to include(:name)
   end
+
+  let(:pkgr_cli) { Pkgr::CLI.new }
+  let(:tmp_destination) { Dir.mktmpdir }
+  let(:data_structure) { ["buildpacks", "build_dependencies",
+                          "cli", "environment", "init",
+                          "logrotate", "dependencies", "hooks"]
+  }
+  let(:copy_of_data) { Dir["#{tmp_destination}/*"].map { |f| File.basename(f) } }
+
+  it "should have a data command" do
+    expect(pkgr_cli.respond_to?(:data)).to be_truthy
+    expect(pkgr_cli.data(tmp_destination)).to eq(nil)
+    expect(copy_of_data).to match_array(data_structure)
+  end
 end


### PR DESCRIPTION
Hi

I improved a bit pkgr by introducing data_dir as configuration option. This will allow users to override any templates which are used for building package. For example we are using it for:

- override preinstall.sh to set different user home directory
- override fedora.yml with dependencies list (we don't want to have mariadb or sqlite if we are using only psql), same for building dependencies

There are also some improvements for fedora package like:
- excluding .git directory
- add license, vendor, category attributes

I am looking forward for your feedback