### PR TITLE
Remove 'daemon?' check and export all processes from procfile when using Upstart

### DIFF
--- a/lib/pkgr/distributions/base.rb
+++ b/lib/pkgr/distributions/base.rb
@@ -118,7 +118,7 @@ module Pkgr
       # Returns a list of <Process, FileTemplate> tuples.
       def initializers_for(app_name, procfile_entries)
         list = []
-        procfile_entries.select(&:daemon?).each do |process|
+        procfile_entries.each do |process|
           Pkgr.debug "Adding #{process.inspect} to initialization scripts"
           runner.templates(process, app_name).each do |template|
             list.push [process, template]

--- a/lib/pkgr/process.rb
+++ b/lib/pkgr/process.rb
@@ -1,7 +1,5 @@
 module Pkgr
   class Process
-    DAEMON_PROCESSES = ["web", "worker"]
-
     attr_reader :name, :command
     attr_accessor :scale
 
@@ -9,10 +7,6 @@ module Pkgr
       @name = name
       @command = command
       @scale = scale || 1
-    end
-
-    def daemon?
-      DAEMON_PROCESSES.include?(name)
     end
   end
 end

--- a/spec/lib/pkgr/distributions/base_spec.rb
+++ b/spec/lib/pkgr/distributions/base_spec.rb
@@ -31,7 +31,7 @@ describe Pkgr::Distributions::Base do
       runner.stub(templates: [double(:template1), double(:template2)])
 
       templates_by_process = distribution.initializers_for("my-app", processes).group_by{|(a,b)| a}
-      expect(templates_by_process.keys.map(&:name)).to eq(["web", "worker"])
+      expect(templates_by_process.keys.map(&:name)).to eq(["web", "console", "worker"])
       expect(templates_by_process[processes[0]].length).to eq(2)
     end
   end


### PR DESCRIPTION
Fixes #36 #22

As per this [comment](https://github.com/crohr/pkgr/issues/22#issuecomment-49540234): 
> Consequently, I think we could remove the hard-coded daemon? check. 

Thank you for creating `pkgr` by the way, it's a really great tool.