### PR TITLE
Dont fail upstart scaledowns if ctl stop does not work.

### DIFF
--- a/data/cli/cli.sh.erb
+++ b/data/cli/cli.sh.erb
@@ -183,7 +183,7 @@ scale_down() {
     PROCESS_ID="${APP_NAME}-${PROCESS_NAME}-${index}"
 
     if [ "${APP_RUNNER_TYPE}" = "upstart" ]; then
-      $APP_RUNNER_CLI stop "${PROCESS_ID}"
+      $APP_RUNNER_CLI stop "${PROCESS_ID}" || /bin/true # dont fail if server stopped differently
       rm -f $(_p "/etc/init/${PROCESS_ID}.conf")
     else
       $(_p "/etc/init.d/${PROCESS_ID}") stop


### PR DESCRIPTION
On at least Ubuntu 14, if some other process has stopped/removed upstart instances for a job, and pkgr thinks it needs to scale down, initctl stop will fail.  This should not stop pkgr's cli script from continuing to scale down, I think.