### PR TITLE
Fixing  forbidden-postrm-interpreter error on Debian 7

### DIFF
--- a/data/hooks/postuninstall.sh
+++ b/data/hooks/postuninstall.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -e
 

--- a/data/hooks/preinstall.sh
+++ b/data/hooks/preinstall.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -e
 

--- a/data/hooks/preuninstall.sh
+++ b/data/hooks/preuninstall.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -e
 

--- a/lib/pkgr/dispatcher.rb
+++ b/lib/pkgr/dispatcher.rb
@@ -40,6 +40,11 @@ module Pkgr
       # Remove any non-digit characters that may be before the version number
       config.version ||= begin
         v = (Git.new(path).latest_tag || "").gsub(/^[^\d]+(\d.*)/, '\1')
+        # If it's not a Git archive, try to figure out svn revision number
+        begin
+          v = `cd #{path.to_s}&&svn info|grep Revision`.to_s.gsub!(/\D/, "") if (v !~ /^\d/)
+        rescue
+        end
         v = "0.0.0" if v !~ /^\d/
         v
       end


### PR DESCRIPTION
On Debian 7, I have received a forbidden-postrm-interpreter error during the installation of a deb package created with pkgr.
It appears that using /usr/bin/env in postrm is violating a policy:
https://lintian.debian.org/tags/forbidden-postrm-interpreter.html

If nothing contradicts, I suggest changing all interpreters of the maintainer scripts to /bin/bash for consistency reasons.
