### PR TITLE
Amazon linux support

### DIFF
--- a/data/build_dependencies/amazon.yml
+++ b/data/build_dependencies/amazon.yml
@@ -1,0 +1,13 @@
+default:
+  - curl
+  - gcc
+  - gcc-c++
+  - kernel-devel
+  - openssl-devel
+  - readline-devel
+  - libxml2-devel
+  - libxslt-devel
+  - libevent-devel
+  - postgresql-devel
+  - mysql-devel
+  - sqlite-devel

--- a/data/buildpacks/amazon-2014
+++ b/data/buildpacks/amazon-2014
@@ -1,0 +1,3 @@
+https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/heroku/heroku-buildpack-nodejs.git#v58
+https://github.com/kr/heroku-buildpack-go.git

--- a/data/dependencies/amazon.yml
+++ b/data/dependencies/amazon.yml
@@ -1,0 +1,9 @@
+default:
+  - openssl
+  - readline
+  - libxml2
+  - libxslt
+  - libevent
+  - postgresql-libs
+  - mysql-libs
+  - sqlite

--- a/data/hooks/preinstall.sh
+++ b/data/hooks/preinstall.sh
@@ -8,7 +8,7 @@ export APP_GROUP="<%= group %>"
 export APP_HOME="<%= home %>"
 
 if ! getent passwd "${APP_USER}" > /dev/null; then
-  if [ -f /etc/redhat-release ] || [ -f /etc/SuSE-release ]; then
+  if [ -f /etc/redhat-release ] || [ -f /etc/system-release ] || [ -f /etc/SuSE-release ]; then
     if ! getent group "${APP_GROUP}" > /dev/null ; then
       groupadd --system "${APP_GROUP}"
     fi

--- a/lib/pkgr/distributions/amazon.rb
+++ b/lib/pkgr/distributions/amazon.rb
@@ -1,0 +1,6 @@
+module Pkgr
+  module Distributions
+    class Amazon < Redhat
+    end
+  end
+end

--- a/lib/pkgr/distributions/redhat.rb
+++ b/lib/pkgr/distributions/redhat.rb
@@ -7,3 +7,5 @@ module Pkgr
     end
   end
 end
+
+require 'pkgr/distributions/amazon'


### PR DESCRIPTION
With this you can use `pkgr` to build rpms on Amazon Linux. Tested on `amazon-2014.09`.

For ruby I had to change the buildback too, see https://github.com/pkgr/heroku-buildpack-ruby/pull/2.