### PR TITLE
buildpacks for Amazon Linux 2015

### DIFF
--- a/data/buildpacks/amazon-2015
+++ b/data/buildpacks/amazon-2015
@@ -1,0 +1,3 @@
+https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/heroku/heroku-buildpack-nodejs.git#v58
+https://github.com/kr/heroku-buildpack-go.git


### PR DESCRIPTION
Amazon released version 2015.03 last March. After the update pkgr could not find the buildpack data. 