### PR TITLE
Allow hard-coded defaults to be overridden by pkgr.yml

### DIFF
--- a/lib/pkgr/cli.rb
+++ b/lib/pkgr/cli.rb
@@ -43,8 +43,7 @@ module Pkgr
       :desc => "Maintainer"
     method_option :vendor,
       :type => :string,
-      :desc => "Package vendor",
-      :default => "pkgr <https://github.com/crohr/pkgr>"
+      :desc => "Package vendor"
     method_option :architecture,
       :type => :string,
       :default => "x86_64",

--- a/lib/pkgr/config.rb
+++ b/lib/pkgr/config.rb
@@ -108,6 +108,10 @@ module Pkgr
       @table[:maintainer] || "<someone@pkgr>"
     end
 
+    def vendor
+      @table[:vendor] || "pkgr <https://github.com/crohr/pkgr>"
+    end
+
     def env
       @table[:env].is_a?(Pkgr::Env) ? @table[:env] : Pkgr::Env.new(@table[:env])
     end


### PR DESCRIPTION
Otherwise these take precedence over the config file and can only be overridden by CLI options