### PR TITLE
Run chroot with the user's configured groups

### DIFF
--- a/data/cli/cli.sh.erb
+++ b/data/cli/cli.sh.erb
@@ -300,7 +300,8 @@ while : ; do
       if [ $(id -u) = $(id -u ${APP_USER}) ]; then
         exec sh -c "cd $(_p ${APP_HOME}) && $runnable"
       else
-        exec chroot --userspec ${APP_USER}:${APP_GROUP} "/" sh -c "cd $(_p ${APP_HOME}) && $runnable"
+        additional_groups="$(id -Gn ${APP_USER} |  tr ' ' ',')"
+        exec chroot --userspec ${APP_USER}:${APP_GROUP} --groups="${additional_groups}" "/" sh -c "cd $(_p ${APP_HOME}) && $runnable"
       fi
 
       break ;;


### PR DESCRIPTION
This extension passes the user's full groups to the chroot command,
in order to let the command run with the full membership permissions
of the user itself.

This avoids the differences in permission when executing `<command> run
.. ` as root compared to running it as the user itself, given that the user is member of a
custom group G.