### PR TITLE
Try a newer version of bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler
 before_script:
   - git config --global user.email hello@world.com
   - git config --global user.name "John Doe"


### PR DESCRIPTION
Build was failing like this:

Installing rspec 2.99.0
Installing fpm 1.4.0
NoMethodError: undefined method `spec' for nil:NilClass
An error occurred while installing pkgr
(1.4.4), and Bundler cannot continue.
Make sure that `gem install pkgr -v
'1.4.4'` succeeds before bundling.
The command "eval bundle install --jobs=3 --retry=3" failed. Retrying, 2 of 3.