### PR TITLE
[WIP] The app's user's home directory should be the same as the app home

### DIFF
--- a/data/hooks/preinstall.sh
+++ b/data/hooks/preinstall.sh
@@ -12,12 +12,12 @@ if ! getent passwd "${APP_USER}" > /dev/null; then
     if ! getent group "${APP_GROUP}" > /dev/null ; then
       groupadd --system "${APP_GROUP}"
     fi
-    useradd "${APP_USER}" -g "${APP_GROUP}" --system --create-home --shell /bin/bash
+    useradd "${APP_USER}" -g "${APP_GROUP}" --system --create-home --home-dir "${APP_HOME}" --shell /bin/bash
   else
     if ! getent group "${APP_GROUP}" > /dev/null; then
       addgroup "${APP_GROUP}" --system --quiet
     fi
-    adduser "${APP_USER}" --disabled-login --ingroup "${APP_GROUP}" --system --quiet --shell /bin/bash
+    adduser "${APP_USER}" --disabled-login --ingroup "${APP_GROUP}" --system --quiet --home "${APP_HOME}" --shell /bin/bash
   fi
 fi
 

--- a/lib/pkgr/buildpack.rb
+++ b/lib/pkgr/buildpack.rb
@@ -36,7 +36,7 @@ module Pkgr
     end
 
     def compile(path, compile_cache_dir, compile_env_dir)
-      cmd = %{env -i PATH="$PATH"#{env} #{dir}/bin/compile "#{path}" "#{compile_cache_dir}" "#{compile_env_dir}" }
+      cmd = %{env -i PATH="$PATH"#{env} HOME=#{path} #{dir}/bin/compile "#{path}" "#{compile_cache_dir}" "#{compile_env_dir}" }
       Pkgr.debug "Running #{cmd.inspect}"
 
       Dir.chdir(path) do


### PR DESCRIPTION
Buildpacks sometimes place files in compile time $HOME, such as language package caches, and these must be in the app's runtime $HOME.