### PR TITLE
Fix #104: CLI flags for disabling default dependencies and cli

### DIFF
--- a/lib/pkgr/cli.rb
+++ b/lib/pkgr/cli.rb
@@ -109,6 +109,10 @@ module Pkgr
       :type => :array,
       :default => [],
       :desc => "Specific system dependencies that must be present before building"
+    method_option :disable_default_dependencies,
+      :type => :boolean,
+      :default => false,
+      :desc => "Disable default dependencies"
     method_option :host,
       :type => :string,
       :desc => "Remote host to build on (default: local machine)"
@@ -146,6 +150,10 @@ module Pkgr
       :type => :string,
       :default => nil,
       :desc => "Recursively mark a directory as being owned by the package"
+    method_option :disable_cli,
+      :type => :boolean,
+      :default => false,
+      :desc => "Disable installing CLI"
 
     def package(tarball)
       Pkgr.level = Logger::INFO if options[:verbose]

--- a/lib/pkgr/config.rb
+++ b/lib/pkgr/config.rb
@@ -73,11 +73,19 @@ module Pkgr
     end
 
     def cli?
-      @table.has_key?(:cli) ? @table[:cli] : true
+      if disable_cli.nil?
+        @table.has_key?(:cli) ? @table[:cli] : true
+      else
+        !disable_cli
+      end
     end
 
     def skip_default_dependencies?
-      @table[:default_dependencies] === false
+      if disable_default_dependencies.nil?
+        @table[:default_dependencies] === false
+      else
+        disable_default_dependencies == true
+      end
     end
 
     def home

--- a/spec/lib/pkgr/config_spec.rb
+++ b/spec/lib/pkgr/config_spec.rb
@@ -1,7 +1,16 @@
 require File.dirname(__FILE__) + '/../../spec_helper'
 
 describe Pkgr::Config do
-  let(:config) { Pkgr::Config.new(:version => "0.0.1", :name => "my-app", :iteration => "1234", :env => ["RACK_ENV=staging", "CURL_TIMEOUT=250"]) }
+  let(:options) do
+    {
+      :version => "0.0.1",
+      :name => "my-app",
+      :iteration => "1234",
+      :env => ["RACK_ENV=staging", "CURL_TIMEOUT=250"]
+    }
+  end
+
+  let(:config) { Pkgr::Config.new(options) }
 
   it "is valid" do
     expect(config).to be_valid
@@ -121,6 +130,104 @@ describe Pkgr::Config do
     it "correctly exports the crons if any" do
       config = Pkgr::Config.new(crons: ["path/to/cron1", "path/to/cron2"])
       expect(config.crons).to eq(["path/to/cron1", "path/to/cron2"])
+    end
+  end
+
+  describe "#skip_default_dependencies?" do
+    context "default configuration" do
+      it "returns false" do
+        expect(config.skip_default_dependencies?).to eq(false)
+      end
+
+      context "when default_dependencies is set to false in .pkgr.yml" do
+        let(:options) { super().merge(default_dependencies: false) }
+
+        it "returns true" do
+          expect(config.skip_default_dependencies?).to eq(true)
+        end
+      end
+
+      context "when default_dependencies is set to an array in .pkgr.yml" do
+        let(:options) { super().merge(default_dependencies: ['foo']) }
+
+        it "returns false" do
+          expect(config.skip_default_dependencies?).to eq(false)
+        end
+      end
+    end
+
+    context "when --disable-default-dependencies is passed" do
+      let(:options) { super().merge(disable_default_dependencies: true) }
+
+      it "returns true" do
+        expect(config.skip_default_dependencies?).to eq(true)
+      end
+
+      context "when default_dependencies is set to an array in .pkgr.yml" do
+        let(:options) { super().merge(default_dependencies: ['foo']) }
+
+        it "returns true" do
+          expect(config.skip_default_dependencies?).to eq(true)
+        end
+      end
+    end
+
+    context "when --no-disable-default-dependencies is passed" do
+      let(:options) { super().merge(disable_default_dependencies: false) }
+
+      it "returns false" do
+        expect(config.skip_default_dependencies?).to eq(false)
+      end
+
+      context "when default_dependencies is set to false in .pkgr.yml" do
+        let(:options) { super().merge(default_dependencies: false) }
+
+        it "returns false" do
+          expect(config.skip_default_dependencies?).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe '#cli?' do
+    context "default configuration" do
+      it "returns false" do
+        expect(config.cli?).to eq(true)
+      end
+    end
+
+    context 'when the --disable-cli flag is not passed' do
+      context "when cli is set to false in .pkgr.yml" do
+        let(:options) { super().merge(cli: false) }
+
+        it "returns false" do
+          expect(config.cli?).to eq(false)
+        end
+      end
+    end
+
+    context 'when the --disable-cli flag is passed' do
+      let(:options) { super().merge(disable_cli: true) }
+
+      it "returns false" do
+        expect(config.cli?).to eq(false)
+      end
+    end
+
+    context 'when the --no-disable-cli flag is passed' do
+      let(:options) { super().merge(disable_cli: false) }
+
+      it "returns true" do
+        expect(config.cli?).to eq(true)
+      end
+
+      context "when cli is set to false in .pkgr.yml" do
+        let(:options) { super().merge(cli: false) }
+
+        it "returns true" do
+          expect(config.cli?).to eq(true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add new cli flag "--disable-default-dependencies"

When this flag is passed, the default dependencies will not be
included.

Add new cli flag "--disable-cli"

This flag can be used to disable installing CLI.