### PR TITLE
Fix Ruby buildpack location, and add Python buildpack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Goal
 
-Make debian or rpm packages out of any app, including init script, crons, logrotate, etc. Excellent way to distribute apps or command line tools without complicated installation instructions.
+Make debian or rpm packages out of any app, including init script, crons,
+logrotate, etc. Excellent way to distribute apps or command line tools without
+complicated installation instructions.
 
 Hosted service available at <https://packager.io/>. Free for OpenSource apps.
 
@@ -10,12 +12,19 @@ Hosted service available at <https://packager.io/>. Free for OpenSource apps.
 
 * Ruby
 * NodeJS
+* Python
 * Go
 
-You can also point to other buildpacks ([doc](https://packager.io/documentation/customizing-the-build/#buildpack)). They may just work.
+You can also try out PHP support by specifying the following buildpack:
+`https://github.com/pkgr/heroku-buildpack-php#buildcurl`
+
+You can also point to other buildpacks
+([doc](https://packager.io/documentation/customizing-the-build/#buildpack)).
+They may just work.
 
 ## Supported distributions (64bits only)
 
+* Ubuntu 16.04 ("xenial")
 * Ubuntu 14.04 ("trusty")
 * Ubuntu 12.04 ("precise")
 * Debian 8 ("jessie")
@@ -23,7 +32,8 @@ You can also point to other buildpacks ([doc](https://packager.io/documentation/
 * RHEL/CentOS 7
 * RHEL/CentOS 6
 * Suse Linux Enterprise Server 12
-* Fedora 20
+* Suse Linux Enterprise Server 11
+* Amazon Linux AMI 2015
 * Amazon Linux AMI 2014
 
 ## Examples

--- a/data/buildpacks/amazon-2014
+++ b/data/buildpacks/amazon-2014
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/amazon-2015
+++ b/data/buildpacks/amazon-2015
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/centos-6
+++ b/data/buildpacks/centos-6
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/centos-7
+++ b/data/buildpacks/centos-7
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-6
+++ b/data/buildpacks/debian-6
@@ -1,2 +1,3 @@
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-ruby.git,CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
-https://github.com/heroku/heroku-buildpack-nodejs.git

--- a/data/buildpacks/debian-7
+++ b/data/buildpacks/debian-7
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-8
+++ b/data/buildpacks/debian-8
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/fedora-20
+++ b/data/buildpacks/fedora-20
@@ -1,2 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58

--- a/data/buildpacks/sles-11
+++ b/data/buildpacks/sles-11
@@ -1,2 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58

--- a/data/buildpacks/sles-12
+++ b/data/buildpacks/sles-12
@@ -1,2 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58

--- a/data/buildpacks/ubuntu-10.04
+++ b/data/buildpacks/ubuntu-10.04
@@ -1,2 +1,3 @@
-https://github.com/heroku/heroku-buildpack-ruby.git,CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git

--- a/data/buildpacks/ubuntu-12.04
+++ b/data/buildpacks/ubuntu-12.04
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-14.04
+++ b/data/buildpacks/ubuntu-14.04
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#universal,BUILDPACK_NODE_VERSION="0.6.8",CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-16.04
+++ b/data/buildpacks/ubuntu-16.04
@@ -1,3 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git,CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300
+https://github.com/pkgr/heroku-buildpack-ruby.git#buildcurl,BUILDPACK_NODE_VERSION="0.6.8"
+https://github.com/pkgr/heroku-buildpack-python.git#buildcurl
 https://github.com/heroku/heroku-buildpack-nodejs.git#v58
 https://github.com/kr/heroku-buildpack-go.git


### PR DESCRIPTION
The latest versions of both Ruby and Python will be compiled on demand.