### PR TITLE
Replace PORT_NUM for systemd process as well

### DIFF
--- a/data/cli/cli.sh.erb
+++ b/data/cli/cli.sh.erb
@@ -107,7 +107,7 @@ update_port() {
   if [ "${process_name}" = "web" ]; then
     sed -i "s/PORT_NUM/${port}/g" "${file}"
   else
-    sed -i "s/^env .*PORT_NUM.*$//g" "${file}"
+    sed -i "s/^env.*PORT_NUM$//Ig" ${file}"
     sed -i "s/^export PORT=PORT_NUM$//g" "${file}"
   fi
 }


### PR DESCRIPTION
update_port method should remove the line which consist PORT_NUM in three place: lsb-3.1/process.erb, upstart/1.5/process.conf.erb and systemd/default/process.service.erb. Modified regexp handle lsb and systemd.

As reference project search:

```
Searching 122 files for "PORT_NUM" (case sensitive)

/Volumes/code/monterail/sf/pkgr/CHANGELOG.md:
  103  * Remove upstart dependency.
  104  * Add sysvinit support for debian distros.
  105: * Fix PORT_NUM substitution.
  106  * Allow to set a maintainer for the package.
  107  * Rescue more errors, for better display.

/Volumes/code/monterail/sf/pkgr/data/cli/cli.sh.erb:
  106    sed -i "s/PROCESS_NUM/${index}/g" "${file}"
  107    if [ "${process_name}" = "web" ]; then
  108:     sed -i "s/PORT_NUM/${port}/g" "${file}"
  109    else
  110:     sed -i "s/^env .*PORT_NUM.*$//g" "${file}"
  111:     sed -i "s/^export PORT=PORT_NUM$//g" "${file}"
  112    fi
  113  }

/Volumes/code/monterail/sf/pkgr/data/init/systemd/default/process.service.erb:
    5  
    6  [Service]
    7: Environment=PORT=PORT_NUM
    8  ExecStart=/usr/bin/<%= name %> run <%= process_name %>
    9  Restart=always

/Volumes/code/monterail/sf/pkgr/data/init/sysv/lsb-3.1/process.erb:
   15  
   16  export PATH=/sbin:/usr/sbin:/bin:/usr/bin
   17: export PORT=PORT_NUM
   18  
   19  name="<%= name %>"

/Volumes/code/monterail/sf/pkgr/data/init/upstart/1.5/process.conf.erb:
    3  respawn
    4  
    5: env PORT=PORT_NUM
    6  
    7  exec <%= name %> run <%= process_name %> >> /var/log/<%= name %>/<%= process_name %>-PROCESS_NUM.log 2>&1

7 matches across 5 file
```
