### PR TITLE
fix sles 12 - needs postgresql94 not postgresql93

### DIFF
--- a/data/dependencies/sles.yml
+++ b/data/dependencies/sles.yml
@@ -12,4 +12,4 @@ sles-11:
   - postgresql
 sles-12:
   - libmysqlclient18
-  - postgresql94
+  - postgresql94 | postgresql93

--- a/data/dependencies/sles.yml
+++ b/data/dependencies/sles.yml
@@ -12,4 +12,4 @@ sles-11:
   - postgresql
 sles-12:
   - libmysqlclient18
-  - postgresql93
+  - postgresql94


### PR DESCRIPTION
- fixing data/dependencies/sles.yml.
- added postgresql94
- removed postgresql93
