### PR TITLE
Allow the user to specify a tmpdir for hooks

### DIFF
--- a/data/hooks/postinstall.sh
+++ b/data/hooks/postinstall.sh
@@ -43,7 +43,7 @@ echo "=============="
 # Call custom postinstall script.
 CUSTOM_POSTINSTALL_SCRIPT="<%= Base64.encode64 File.read(after_install) %>"
 
-tmpfile=$(mktemp)
+<%= "tmpfile=$(#{"TMPDIR=\"#{tmpdir}\" " if tmpdir}mktemp)" %>
 chmod a+x "${tmpfile}"
 echo "${CUSTOM_POSTINSTALL_SCRIPT}" | base64 -d - > ${tmpfile}
 

--- a/data/hooks/postuninstall.sh
+++ b/data/hooks/postuninstall.sh
@@ -18,7 +18,7 @@ fi
 # Call custom postuninstall script.
 CUSTOM_POSTUNINSTALL_SCRIPT="<%= Base64.encode64 File.read(after_remove) %>"
 
-tmpfile=$(mktemp)
+<%= "tmpfile=$(#{"TMPDIR=\"#{tmpdir}\" " if tmpdir}mktemp)" %>
 chmod a+x "${tmpfile}"
 echo "${CUSTOM_POSTUNINSTALL_SCRIPT}" | base64 -d - > ${tmpfile}
 

--- a/data/hooks/preinstall.sh
+++ b/data/hooks/preinstall.sh
@@ -27,7 +27,7 @@ fi
 # https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
 CUSTOM_PREINSTALL_SCRIPT="<%= Base64.encode64 File.read(before_install) %>"
 
-tmpfile=$(mktemp)
+<%= "tmpfile=$(#{"TMPDIR=\"#{tmpdir}\" " if tmpdir}mktemp)" %>
 chmod a+x "${tmpfile}"
 echo "${CUSTOM_PREINSTALL_SCRIPT}" | base64 -d - > ${tmpfile}
 

--- a/data/hooks/preuninstall.sh
+++ b/data/hooks/preuninstall.sh
@@ -10,7 +10,7 @@ export APP_HOME="<%= home %>"
 <% if before_remove && File.readable?(before_remove) %>
 CUSTOM_PREUNINSTALL_SCRIPT="<%= Base64.encode64 File.read(before_remove) %>"
 
-tmpfile=$(mktemp)
+<%= "tmpfile=$(#{"TMPDIR=\"#{tmpdir}\" " if tmpdir}mktemp)" %>
 chmod a+x "${tmpfile}"
 echo "${CUSTOM_PREUNINSTALL_SCRIPT}" | base64 -d - > ${tmpfile}
 

--- a/lib/pkgr/cli.rb
+++ b/lib/pkgr/cli.rb
@@ -152,6 +152,9 @@ module Pkgr
     method_option :disable_cli,
       :type => :boolean,
       :desc => "Disable installing CLI"
+    method_option :tmpdir,
+      :type => :string,
+      :desc => 'Set a custom tmpdir for hook scripts to get created in'
 
     def package(tarball)
       Pkgr.level = Logger::INFO if options[:verbose]

--- a/lib/pkgr/config.rb
+++ b/lib/pkgr/config.rb
@@ -100,6 +100,10 @@ module Pkgr
       @table[:group] || user
     end
 
+    def tmpdir
+      @table[:tmpdir]
+    end
+
     def architecture
       @table[:architecture] || "x86_64"
     end
@@ -251,6 +255,7 @@ module Pkgr
       args.push "--verify" if verify
       args.push "--no-clean" if !clean
       args.push "--no-edge" if !edge
+      args.push "--tmpdir" if !tmpdir
       args
     end
   end

--- a/spec/fixtures/default.erb
+++ b/spec/fixtures/default.erb
@@ -7,3 +7,5 @@ done
 for file in <%= home %>/.profile.d/*.sh; do
   if [ -f $file ]; then . $file; fi
 done
+
+<%= "tmpfile=$(#{"TMPDIR=\"#{tmpdir}\" " if tmpdir}mktemp)" %>

--- a/spec/lib/pkgr/config_spec.rb
+++ b/spec/lib/pkgr/config_spec.rb
@@ -244,4 +244,21 @@ describe Pkgr::Config do
       end
     end
   end
+
+  describe '#tmpdir' do
+    context 'when the --tmpdir flag is not passed' do
+      it 'returns nil when unset' do
+        expect(config.tmpdir).to be_nil
+      end
+    end
+
+    context 'when the --tmpdir flag is passed' do
+      let(:custom_tmpdir) { 'custom_tmpdir' }
+      let(:options) { super().merge(tmpdir: custom_tmpdir) }
+
+      it 'returns the custom tmpdir' do
+        expect(config.tmpdir).to eq(custom_tmpdir)
+      end
+    end
+  end
 end

--- a/spec/lib/pkgr/templates/file_template_spec.rb
+++ b/spec/lib/pkgr/templates/file_template_spec.rb
@@ -10,7 +10,8 @@ describe Pkgr::Templates::FileTemplate do
   end
 
   let(:template) { Pkgr::Templates::FileTemplate.new(@tmpfile.path, File.new(fixture("default.erb"))) }
-  let(:config) { Pkgr::Config.new(:name => "my-app") }
+  let(:options) { {name: "my-app"} }
+  let(:config) { Pkgr::Config.new(options) }
 
   it "writes the expected result to the target file" do
     template.install(config.sesame)
@@ -18,4 +19,26 @@ describe Pkgr::Templates::FileTemplate do
     expect(@tmpfile.read).to include(%{HOME="/opt/my-app"})
   end
 
+  context "tmpfile configuration" do
+    context "with custom tmpdir" do
+      let(:custom_tmpdir) { 'custom_tmpdir' }
+      let(:options) { super().merge(tmpdir: custom_tmpdir) }
+
+      it "sets TMPDIR to the custom tmpdirs value" do
+        template.install(config.sesame)
+        @tmpfile.rewind
+        expect(@tmpfile.read).to include(%{tmpfile=$(TMPDIR="#{custom_tmpdir}" mktemp)})
+      end
+    end
+
+    context "without custom tmpfile" do
+      it "does not set TMPDIR" do
+        template.install(config.sesame)
+        @tmpfile.rewind
+        tmpfile_content = @tmpfile.read
+        expect(tmpfile_content).to_not include("TMPDIR")
+        expect(tmpfile_content).to include("tmpfile=$(mktemp)")
+      end
+    end
+  end
 end


### PR DESCRIPTION
It is common to mount /tmp as noexec on linux, but pkgr uses mktemp to
create a tmpfile in which to output the custom pre/post
install/uninstall scripts, and then tries to exec them. This means that
pkgr generates RPMs that don't function correctly on systems with /tmp
mounted as noexec.

For lots of reasons (yum update being the main one), it is not ideal to
always have the caller set TMPDIR before installing the package, so this
exposes a new command line option (--tmpdir) that allows the user to
specify an alternate directory in which to create the tmp files.