### PR TITLE
Delete PORT environment in systemd

### DIFF
--- a/data/cli/cli.sh.erb
+++ b/data/cli/cli.sh.erb
@@ -109,6 +109,7 @@ update_port() {
   else
     sed -i "s/^env .*PORT_NUM.*$//g" "${file}"
     sed -i "s/^export PORT=PORT_NUM$//g" "${file}"
+    sed -i "s/^Environment=PORT=PORT_NUM$//g" "${file}"
   fi
 }
 


### PR DESCRIPTION
When updating the port on an init script, we delete the PORT if the process is not "web". This has to happen on systemd as well as on upstart and sysv.

This fixes issues people are having with non-web services being deployed via systemd in Ubuntu 16.04 et al. (See #108, #101)