### PR TITLE
Fix #133: /usr/bin conflicts with the "filesystem" package on CentOS 7

### DIFF
--- a/lib/pkgr/distributions/base.rb
+++ b/lib/pkgr/distributions/base.rb
@@ -99,16 +99,17 @@ module Pkgr
         app_name = config.name
         list = []
 
-        # directories
-        [
-          "usr/bin",
+        directories = [
           config.home.gsub(/^\//, ""),
           "etc/#{app_name}/conf.d",
           "etc/default",
           "var/log/#{app_name}",
           "var/db/#{app_name}",
           "usr/share/#{app_name}"
-        ].each{|dir| list.push Templates::DirTemplate.new(dir) }
+        ]
+
+        directories << "usr/bin" if config.cli?
+        directories.each{|dir| list.push Templates::DirTemplate.new(dir) }
 
         list.push Templates::FileTemplate.new("etc/default/#{app_name}", data_file("environment", "default.erb"))
         list.push Templates::FileTemplate.new("etc/logrotate.d/#{app_name}", data_file("logrotate", "logrotate.erb"))


### PR DESCRIPTION
The issue is that when using the `--disable-cli` flag, an empty directory, `/usr/bin`, was created and put inside the package. The fix is to only create that directory if the CLI should be included in the package.