### PR TITLE
Added support for configuration of log rotation frequency and backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Full command line options are given below:
       [--architecture=ARCHITECTURE]                  # Target architecture for the package
                                                      # Default: x86_64
       [--runner=RUNNER]                              # Force a specific runner (e.g. upstart-1.5, sysv-lsb-1.3)
+      [--logrotate-frequency=FREQUENCY]              # Set logrotate frequency
+                                                     # Default: daily
+                                                     # Possible values: daily, weekly, monthly, yearly
+      [--logrotate-backlog=BACKLOG]                  # Set logrotate backlog
+                                                     # Default: 14
       [--homepage=HOMEPAGE]                          # Project homepage (e.g. "https://pkgr.example.org")
       [--home=HOME]                                  # Project home (e.g. "/usr/share/PACKAGE_HOME")
       [--description=DESCRIPTION]                    # Project description
@@ -198,5 +203,3 @@ Issue getting nokogiri to compile? Try the following based on this [comment](htt
 ## Copyright
 
 See LICENSE (MIT)
-
-

--- a/data/logrotate/logrotate.erb
+++ b/data/logrotate/logrotate.erb
@@ -1,8 +1,8 @@
 # <%= name %> logs:
 /var/log/<%= name %>/*.log {
-  daily
+  <%= logrotate_frequency %>
   missingok
-  rotate 14
+  rotate <%= logrotate_backlog %>
   compress
   delaycompress
   notifempty

--- a/lib/pkgr/cli.rb
+++ b/lib/pkgr/cli.rb
@@ -51,6 +51,15 @@ module Pkgr
     method_option :runner,
       :type => :string,
       :desc => "Force a specific runner (e.g. upstart-1.5, sysv-lsb-1.3)"
+    method_option :logrotate_frequency,
+      :type => :string,
+      :desc => "Set logrotate backlog",
+      :enum => %w(daily weekly monthly yearly),
+      :default => "daily"
+    method_option :logrotate_backlog,
+      :type => :numeric,
+      :desc => "Set logrotate backlog",
+      :default => 14
     method_option :homepage,
       :type => :string,
       :desc => "Project homepage"

--- a/lib/pkgr/config.rb
+++ b/lib/pkgr/config.rb
@@ -92,6 +92,14 @@ module Pkgr
       @table[:home] || "/opt/#{name}"
     end
 
+    def logrotate_frequency
+      @table[:logrotate_frequency] || "daily"
+    end
+
+    def logrotate_backlog
+      @table[:logrotate_backlog] || 14
+    end
+
     def user
       @table[:user] || name
     end
@@ -252,6 +260,8 @@ module Pkgr
       args.push "--buildpack_list \"#{buildpack_list}\"" unless buildpack_list.nil? || buildpack_list.empty?
       args.push "--force-os \"#{force_os}\"" unless force_os.nil? || force_os.empty?
       args.push "--runner \"#{runner}\"" unless runner.nil? || runner.empty?
+      args.push "--logrotate-frequency \"#{logrotate_frequency}\"" unless logrotate_frequency.nil? || logrotate_frequency.empty?
+      args.push "--logrotate-backlog \"#{logrotate_backlog}\"" unless logrotate_backlog.nil?
       args.push "--env #{env.variables.map{|v| "\"#{v}\""}.join(" ")}" if env.present?
       args.push "--auto" if auto
       args.push "--verbose" if verbose


### PR DESCRIPTION
The goal of this pull request is to allow command line configuration for the log rotation added to packages.