### PR TITLE
Delay service restart time to not trigger as quickly

### DIFF
--- a/data/init/systemd/default/process.service.erb
+++ b/data/init/systemd/default/process.service.erb
@@ -7,6 +7,7 @@ After=<%= name %>-<%= process_name %>.service
 Environment=APP_PROCESS_INDEX=__PROCESS_INDEX__
 ExecStart=/usr/bin/<%= name %> run <%= process_name %>
 Restart=always
+RestartSec=5
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=%n


### PR DESCRIPTION
I am running into an issue where I need RabbitMQ running for my service. The issue is even if I require RabbitMQ as a startup service for my worker, I still have an issue where RabbitMQ is not stable in that amount of time and my service crashes. With slightly slower restarts my service is able to start successfully once RabbitMQ stabilizes.