### PR TITLE
Add additional test case to builder_spec to increase coverage on the …

### DIFF
--- a/spec/fixtures/Procfile
+++ b/spec/fixtures/Procfile
@@ -1,3 +1,4 @@
 web: bundle exec unicorn
 worker: bundle exec sidekiq
 redis: redis-server
+urgent_web: bundle exec unicorn

--- a/spec/lib/pkgr/builder_spec.rb
+++ b/spec/lib/pkgr/builder_spec.rb
@@ -154,6 +154,7 @@ describe Pkgr::Builder do
         "console",
         "rake",
         "redis",
+        "urgent_web",
         "web",
         "worker"
       ])
@@ -175,6 +176,8 @@ describe Pkgr::Builder do
         "/upstart/my-app-rake.conf",
         "/upstart/my-app-redis-PROCESS_NUM.conf",
         "/upstart/my-app-redis.conf",
+        "/upstart/my-app-urgent_web-PROCESS_NUM.conf",
+        "/upstart/my-app-urgent_web.conf",
         "/upstart/my-app-web-PROCESS_NUM.conf",
         "/upstart/my-app-web.conf",
         "/upstart/my-app-worker-PROCESS_NUM.conf",


### PR DESCRIPTION
Add additional test case to builder_spec to increase coverage on the RegEx used to parse Procfiles.

Namely the use of underscores in this line: https://github.com/crohr/pkgr/blob/master/lib/pkgr/builder.rb#L222