### PR TITLE
Fix #154

### DIFF
--- a/data/cli/cli.sh.erb
+++ b/data/cli/cli.sh.erb
@@ -47,6 +47,7 @@ usage() {
   echo ""
   echo "  $APP_NAME restart [process]"
   echo "    This will restart the application (or the given process), in a distribution-independent manner."
+  exit 64
 }
 
 DEFAULT_FILE=$(_p "/etc/default/${APP_NAME}")


### PR DESCRIPTION
64 since `/usr/include/sysexits.h` uses exit code 64 for `usage`.