### PR TITLE
Fix some compatibility issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04"]
+        os: ["ubuntu-18.04", "ubuntu-20.04"]
         ruby: ["1.9", "2.1", "2.2", "2.3", "2.4", "2.6", "2.7", "3.0"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-18.04"]
+        os: ["ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04"]
         ruby: ["1.9", "2.1", "2.2", "2.3", "2.4", "2.6", "2.7", "3.0"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+---
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ["ubuntu-20.04"]
+        ruby: ["1.9", "2.1", "2.2", "2.3", "2.4", "2.6", "2.7", "3.0"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-18.04"]
         ruby: ["1.9", "2.1", "2.2", "2.3", "2.4", "2.6", "2.7", "3.0"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,7 @@ jobs:
           bundler-cache: true
 
       - name: Run tests
-        run: bundle exec rspec
+        run: |
+          git config --global user.email hello@world.com
+          git config --global user.name "John Doe"
+          bundle exec rspec

--- a/lib/pkgr/buildpack.rb
+++ b/lib/pkgr/buildpack.rb
@@ -24,7 +24,7 @@ module Pkgr
     def initialize(url, type = :builtin, env = nil)
       @uuid = Digest::SHA1.hexdigest(url)
       @url, @branch = url.split("#")
-      @branch ||= "master"
+      @branch ||= "main"
       @type = type
       @env = env || Env.new
     end

--- a/lib/pkgr/env_value.rb
+++ b/lib/pkgr/env_value.rb
@@ -37,6 +37,10 @@ class EnvValue < String
     "#{f}#{self}#{b}"
   end
 
+  def strip
+    self.class.new(super)
+  end
+
   def unquote
     s = self.dup
 


### PR DESCRIPTION
Hello,

I was interested in trying this project out to bundle my Rails application into a deb and had to do a few tweaks to make this work:

1. Add method `EnvValue#strip` to return an `EnvValue` instead of a `String` (this might be a Ruby 3.0 change?)
2. I noticed the default branch of the Ruby buildpack changed from `master` to `main` so I changed the default value to make the tests pass.

After testing, I was able to use it to successfully build a deb of my project.

Since I was testing this out in GitHub Actions, I left my workflow file for now. If you'd rather not use it, I can remove it. Right now it is testing against the following:

- Ruby versions 1.9, 2.1, 2.2, 2.3, 2.4, 2.6, 2.7, 3.0
- Ubuntu versions 18.04 and 20.04

I was aiming to match the versions that were covered in Travis CI with exception of Ubuntu 16.04 which I don't think is available for GitHub Actions.

Hopefully this looks good, if you have any concerns please let me know.

Thanks for the project!