### PR TITLE
Mark files in etc/ as config files

### DIFF
--- a/lib/pkgr/distributions/base.rb
+++ b/lib/pkgr/distributions/base.rb
@@ -127,6 +127,13 @@ module Pkgr
         list
       end
 
+      def config_files
+        templates
+          .filter { |template| template.is_a?(Templates::FileTemplate) }
+          .map(&:target)
+          .filter { |target| target.start_with?("etc/") }
+      end
+
       # Returns a list of <Process, FileTemplate> tuples.
       def initializers_for(app_name, procfile_entries)
         list = []

--- a/lib/pkgr/fpm_command.rb
+++ b/lib/pkgr/fpm_command.rb
@@ -40,6 +40,7 @@ module Pkgr
       list << "--directories" << config.directories unless config.directories.nil?
       list << "--rpm-digest" << "sha256" if distribution.rpm?
       distribution.dependencies(config.dependencies).each{|d| list << "-d" << d}
+      distribution.config_files.each{|f| list << "--config-files" << f}
       list.compact
     end
   end


### PR DESCRIPTION
This prevents accidentally overwriting customizations made to those files when upgrading a package. For instance when customizing logrotate settings.