### PR TITLE
Add Ubuntu 26.04 EL 10 and SLES 16 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,13 @@ jobs:
           - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:24.04
+          - ubuntu:26.04
           - el:8
           - el:9
+          - el:10
           - sles:12
           - sles:15
+          - sles:16
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ They may just work.
 
 ## Supported distributions (64bits only)
 
+* Ubuntu 26.04
 * Ubuntu 24.04 ("noble")
 * Ubuntu 22.04 ("jammy")
 * Ubuntu 20.04 ("focal")
@@ -43,10 +44,12 @@ They may just work.
 * Debian 9 ("stretch")
 * Debian 8 ("jessie")
 * Debian 7 ("wheezy")
+* RHEL/CentOS 10
 * RHEL/CentOS 9
 * RHEL/CentOS 8
 * RHEL/CentOS 7
 * RHEL/CentOS 6
+* Suse Linux Enterprise Server 16
 * Suse Linux Enterprise Server 15
 * Suse Linux Enterprise Server 12
 * Suse Linux Enterprise Server 11

--- a/data/build_dependencies/centos.yml
+++ b/data/build_dependencies/centos.yml
@@ -15,3 +15,5 @@ centos-7:
   - mariadb-devel
 centos-8:
   - mariadb-devel
+centos-10:
+  - mariadb-devel

--- a/data/build_dependencies/sles.yml
+++ b/data/build_dependencies/sles.yml
@@ -19,3 +19,5 @@ sles-12:
   - postgresql-devel
 sles-15:
   - postgresql-devel
+sles-16:
+  - postgresql-devel

--- a/data/build_dependencies/ubuntu.yml
+++ b/data/build_dependencies/ubuntu.yml
@@ -25,3 +25,5 @@ ubuntu-22.04:
   - libssl3
 ubuntu-24.04:
   - libssl3
+ubuntu-26.04:
+  - libssl3

--- a/data/buildpacks/amazon-2014
+++ b/data/buildpacks/amazon-2014
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/amazon-2015
+++ b/data/buildpacks/amazon-2015
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/centos-10
+++ b/data/buildpacks/centos-10
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/centos-10
+++ b/data/buildpacks/centos-10
@@ -1,0 +1,4 @@
+https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-python#v221-1
+https://github.com/heroku/heroku-buildpack-nodejs.git#v315
+https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/centos-6
+++ b/data/buildpacks/centos-6
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/centos-7
+++ b/data/buildpacks/centos-7
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/centos-8
+++ b/data/buildpacks/centos-8
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/centos-9
+++ b/data/buildpacks/centos-9
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-10
+++ b/data/buildpacks/debian-10
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-11
+++ b/data/buildpacks/debian-11
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-12
+++ b/data/buildpacks/debian-12
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-13
+++ b/data/buildpacks/debian-13
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-6
+++ b/data/buildpacks/debian-6
@@ -1,3 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-ruby.git,CURL_CONNECT_TIMEOUT=60,CURL_TIMEOUT=300

--- a/data/buildpacks/debian-7
+++ b/data/buildpacks/debian-7
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-8
+++ b/data/buildpacks/debian-8
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/debian-9
+++ b/data/buildpacks/debian-9
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/fedora-20
+++ b/data/buildpacks/fedora-20
@@ -1,3 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315

--- a/data/buildpacks/sles-11
+++ b/data/buildpacks/sles-11
@@ -1,3 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315

--- a/data/buildpacks/sles-12
+++ b/data/buildpacks/sles-12
@@ -1,3 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315

--- a/data/buildpacks/sles-15
+++ b/data/buildpacks/sles-15
@@ -1,3 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315

--- a/data/buildpacks/sles-16
+++ b/data/buildpacks/sles-16
@@ -1,3 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315

--- a/data/buildpacks/sles-16
+++ b/data/buildpacks/sles-16
@@ -1,0 +1,3 @@
+https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-python#v221-1
+https://github.com/heroku/heroku-buildpack-nodejs.git#v315

--- a/data/buildpacks/ubuntu-10.04
+++ b/data/buildpacks/ubuntu-10.04
@@ -1,3 +1,3 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315

--- a/data/buildpacks/ubuntu-12.04
+++ b/data/buildpacks/ubuntu-12.04
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-14.04
+++ b/data/buildpacks/ubuntu-14.04
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-16.04
+++ b/data/buildpacks/ubuntu-16.04
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-18.04
+++ b/data/buildpacks/ubuntu-18.04
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-20.04
+++ b/data/buildpacks/ubuntu-20.04
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-22.04
+++ b/data/buildpacks/ubuntu-22.04
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-24.04
+++ b/data/buildpacks/ubuntu-24.04
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-26.04
+++ b/data/buildpacks/ubuntu-26.04
@@ -1,4 +1,4 @@
-https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-ruby.git#v356-1
 https://github.com/pkgr/heroku-buildpack-python#v221-1
 https://github.com/heroku/heroku-buildpack-nodejs.git#v315
 https://github.com/kr/heroku-buildpack-go.git

--- a/data/buildpacks/ubuntu-26.04
+++ b/data/buildpacks/ubuntu-26.04
@@ -1,0 +1,4 @@
+https://github.com/pkgr/heroku-buildpack-ruby.git#v327-1
+https://github.com/pkgr/heroku-buildpack-python#v221-1
+https://github.com/heroku/heroku-buildpack-nodejs.git#v315
+https://github.com/kr/heroku-buildpack-go.git

--- a/data/dependencies/centos.yml
+++ b/data/dependencies/centos.yml
@@ -13,3 +13,5 @@ centos-8:
   - libpq
 centos-9:
   - libpq
+centos-10:
+  - libpq

--- a/data/dependencies/sles.yml
+++ b/data/dependencies/sles.yml
@@ -11,3 +11,4 @@ sles-11:
 sles-12:
   - postgresql
 sles-15: []
+sles-16: []

--- a/data/dependencies/ubuntu.yml
+++ b/data/dependencies/ubuntu.yml
@@ -48,3 +48,7 @@ ubuntu-24.04:
   - libreadline8
   - libssl3
   - libev4
+ubuntu-26.04:
+  - libreadline8
+  - libssl3
+  - libev4

--- a/lib/pkgr/buildpack.rb
+++ b/lib/pkgr/buildpack.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'digest/sha1'
+require 'shellwords'
 
 module Pkgr
   class Buildpack
@@ -85,7 +86,12 @@ module Pkgr
     def refresh(edge = true)
       return if !edge
       Dir.chdir(dir) do
-        buildpack_refresh = Mixlib::ShellOut.new("git fetch origin && ( git reset --hard #{branch} || git reset --hard origin/#{branch} ) && chmod -f +x bin/detect && chmod -f +x bin/compile && chmod -f +x bin/release")
+        git_fetch = Mixlib::ShellOut.new("git fetch --tags origin")
+        git_fetch.logger = Pkgr.logger
+        git_fetch.run_command
+        git_fetch.error!
+
+        buildpack_refresh = Mixlib::ShellOut.new("git reset --hard #{Shellwords.shellescape(ref_for_checkout)} && chmod -f +x bin/detect && chmod -f +x bin/compile && chmod -f +x bin/release")
         buildpack_refresh.logger = Pkgr.logger
         buildpack_refresh.run_command
         buildpack_refresh.error!
@@ -116,6 +122,21 @@ module Pkgr
     end
 
   private
+
+    def ref_for_checkout
+      [
+        "refs/remotes/origin/#{branch}",
+        "refs/tags/#{branch}",
+        "refs/heads/#{branch}"
+      ].find { |ref| git_ref_exists?(ref) } || branch
+    end
+
+    def git_ref_exists?(ref)
+      git_ref = Mixlib::ShellOut.new("git rev-parse --verify --quiet #{Shellwords.shellescape(ref)}")
+      git_ref.logger = Pkgr.logger
+      git_ref.run_command
+      git_ref.exitstatus == 0
+    end
 
     def compound_environment(path, local_env = Env.new)
       Env.new(['PATH=$PATH']).merge(local_env).merge(env).merge(exported_environment(File.join(path, "export")))

--- a/spec/lib/pkgr/addon_spec.rb
+++ b/spec/lib/pkgr/addon_spec.rb
@@ -64,7 +64,7 @@ describe Pkgr::Addon do
 
       addon.install! 'spec/tmp/somedir'
 
-      expect(File.exists?('spec/tmp/somedir/mysql/bin/compile')).to be true
+      expect(File.exist?('spec/tmp/somedir/mysql/bin/compile')).to be true
     end
   end
 end

--- a/spec/lib/pkgr/buildpack_spec.rb
+++ b/spec/lib/pkgr/buildpack_spec.rb
@@ -1,14 +1,43 @@
 require File.dirname(__FILE__) + '/../../spec_helper'
 require 'fileutils'
+require 'tmpdir'
 
 describe Pkgr::Buildpack do
+  def create_buildpack_repo
+    @source_repo_dir = Dir.mktmpdir("buildpack-source")
+
+    Dir.chdir(@source_repo_dir) do
+      raise "git init failed" unless system("git init -q --initial-branch=main .")
+      raise "git config user.email failed" unless system("git config user.email 'hello@world.com'")
+      raise "git config user.name failed" unless system("git config user.name 'John Doe'")
+
+      FileUtils.mkdir_p("bin")
+      %w[detect compile release].each do |file|
+        File.write("bin/#{file}", "#!/bin/sh\n")
+      end
+      File.write("TAG_MARKER", "tagged buildpack\n")
+      raise "git add failed" unless system("git add bin TAG_MARKER")
+      raise "git commit failed" unless system("git commit -q -m 'tag ref'")
+      raise "git tag failed" unless system("git tag v1")
+
+      raise "git checkout failed" unless system("git checkout -q -b universal")
+      File.write("BRANCH_MARKER", "branch buildpack\n")
+      raise "git add failed" unless system("git add BRANCH_MARKER")
+      raise "git commit failed" unless system("git commit -q -m 'branch ref'")
+      raise "git checkout failed" unless system("git checkout -q main")
+    end
+
+    @source_repo_dir
+  end
+
   after do
+    FileUtils.remove_entry_secure(@source_repo_dir) if @source_repo_dir && File.directory?(@source_repo_dir)
     Pkgr::Buildpack.buildpacks_cache_dir = nil
   end
 
   it "initializes with a url" do
     buildpack = Pkgr::Buildpack.new("http://some/url")
-    buildpack.url.should == "http://some/url"
+    expect(buildpack.url).to eq("http://some/url")
   end
 
   describe "#install" do
@@ -17,23 +46,21 @@ describe Pkgr::Buildpack do
     end
 
     it "works with branches" do
-      buildpack = Pkgr::Buildpack.new("https://github.com/pkgr/heroku-buildpack-ruby.git#universal")
+      buildpack = Pkgr::Buildpack.new("#{create_buildpack_repo}#universal")
       expect do
         buildpack.install
       end.to_not raise_error
-      Dir.chdir(buildpack.dir) do
-        expect(%x{git diff origin/universal}).to eq("")
-      end
+      expect(File.exist?(File.join(buildpack.dir, "BRANCH_MARKER"))).to be(true)
+      expect(File.exist?(File.join(buildpack.dir, "TAG_MARKER"))).to be(true)
     end
 
     it "works with tags" do
-      buildpack = Pkgr::Buildpack.new("https://github.com/heroku/heroku-buildpack-nodejs.git#v58")
+      buildpack = Pkgr::Buildpack.new("#{create_buildpack_repo}#v1")
       expect do
         buildpack.install
       end.to_not raise_error
-      Dir.chdir(buildpack.dir) do
-        expect(%x{git log HEAD --oneline}).to include("97a5856")
-      end
+      expect(File.exist?(File.join(buildpack.dir, "TAG_MARKER"))).to be(true)
+      expect(File.exist?(File.join(buildpack.dir, "BRANCH_MARKER"))).to be(false)
     end
   end
 

--- a/spec/lib/pkgr/distributions/modern_targets_spec.rb
+++ b/spec/lib/pkgr/distributions/modern_targets_spec.rb
@@ -1,0 +1,29 @@
+require File.dirname(__FILE__) + '/../../../spec_helper'
+
+describe "modern distro target data" do
+  let(:config) { Pkgr::Config.new }
+
+  it "loads ubuntu 26.04 runtime and build dependencies" do
+    distribution = Pkgr::Distributions::Ubuntu.new("26.04", config)
+
+    expect(distribution.dependencies).to include("libssl3", "libev4")
+    expect(distribution.build_dependencies).to include("libssl3")
+    expect(distribution.buildpacks.last).to_not be_empty
+  end
+
+  it "loads centos 10 runtime and build dependencies" do
+    distribution = Pkgr::Distributions::Centos.new("10", config)
+
+    expect(distribution.dependencies).to include("libpq")
+    expect(distribution.build_dependencies).to include("mariadb-devel")
+    expect(distribution.buildpacks.last).to_not be_empty
+  end
+
+  it "loads sles 16 runtime and build dependencies" do
+    distribution = Pkgr::Distributions::Sles.new("16", config)
+
+    expect(distribution.dependencies).to include("openssl", "sqlite3")
+    expect(distribution.build_dependencies).to include("postgresql-devel")
+    expect(distribution.buildpacks.last).to_not be_empty
+  end
+end


### PR DESCRIPTION
## Summary
Add data, docs, tests, and publish workflow entries for Ubuntu 26.04, EL 10, and SLES 16.

## Changes
- add buildpack manifests for the new targets
- add runtime and build dependency entries for the new distro versions
- extend the GHCR publish matrix with the new targets
- document the new supported distributions in the README
- add focused specs for the new distro data lookups

## Validation
- bundle exec rspec spec/lib/pkgr/distributions_spec.rb spec/lib/pkgr/distributions/debian_spec.rb spec/lib/pkgr/distributions/centos_spec.rb spec/lib/pkgr/distributions/modern_targets_spec.rb
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "yaml_ok"'
- bundle exec rspec *(fails on pre-existing host-specific issues: sudo-dependent CLI specs on macOS, Darwin distro detection, deprecated File.exists?, and buildpack tag/branch fetch tests)*
